### PR TITLE
Bug #159944 fix: Frontend - demosite - Vendor registration - Change payment gateway and check how error messages are displayed - check description for details

### DIFF
--- a/src/com_tjvendors/media/js/tjvendors.js
+++ b/src/com_tjvendors/media/js/tjvendors.js
@@ -335,7 +335,7 @@ var tjCommon = {
 					} 
 					else if (!response && userObject.payment_gateway != "") {
 						var error_html = Joomla.JText._('COM_TJVENDOR_PAYMENTGATEWAY_NO_FIELD_MESSAGE');
-						$thisId.closest('.subform-repeatable-group').append("<div class='alert alert-warning payment-gateway-parent'>" + error_html + "</div>");
+						jQuery("#system-message-container").html("<div class='alert alert-warning payment-gateway-parent'>" + error_html +"<button data-dismiss='alert' class='close' type='button'>×</button></div>");
 					}
 				}
 			});


### PR DESCRIPTION
Steps to reproduce :
1. Frontend - launch demo website
2. As a registered vendor do successful login
3. Under Events, toolbar go to 'Vendor Registration'
4. Click on the profile name
5. By default the Vendor Information section has open, go to 'Payment Gateway Details' section
6. Change payment gateway and select 'authorizenet' from the dropdown
7. Select 'ByCheck' payment gateway from the dropdown
8. Select 'linkpoint' payment gateway from the dropdown

Expected - Error messages should be displayed on the top above form
- All error messages should not display one below one on the page

![clipboard-202004131647-70vcd](https://user-images.githubusercontent.com/58463266/81380942-66a50980-9129-11ea-92d6-067ca5d98330.png)
