### PR TITLE
Bug #160939 fix: Create campaign form - the top message didn't get remove if the vendor information form filled with all fields

### DIFF
--- a/src/com_tjvendors/site/includes/vendor.php
+++ b/src/com_tjvendors/site/includes/vendor.php
@@ -623,8 +623,7 @@ class TjvendorsVendor extends CMSObject
 		$total += (!empty($data->website_address)) ? 5: 0;
 		$total += (!empty($data->vat_number)) ? 5: 0;
 		$total += (!empty($data->vendor_description)) ? 5: 0;
-		$total += (!empty($data->vendor_logo))? 5: 0;
-		$total += (!empty($data->payment_gateway)) ? 5: 0;
+		$total += (!empty($data->vendor_logo))? 10: 0;
 
 		return $total;
 	}

--- a/src/com_tjvendors/site/includes/vendor.php
+++ b/src/com_tjvendors/site/includes/vendor.php
@@ -623,7 +623,8 @@ class TjvendorsVendor extends CMSObject
 		$total += (!empty($data->website_address)) ? 5: 0;
 		$total += (!empty($data->vat_number)) ? 5: 0;
 		$total += (!empty($data->vendor_description)) ? 5: 0;
-		$total += (!empty($data->vendor_logo))? 10: 0;
+		$total += (!empty($data->vendor_logo))? 5: 0;
+		$total += (!empty($data->payment_gateway)) ? 5: 0;
 
 		return $total;
 	}

--- a/src/com_tjvendors/site/views/vendor/tmpl/edit.php
+++ b/src/com_tjvendors/site/views/vendor/tmpl/edit.php
@@ -55,10 +55,7 @@ if (Factory::getUser()->id)
 			}
 		?>
 	</h1>
-	<form action="<?php echo Route::_('index.php?option=com_tjvendors&layout=edit&vendor_id=' .
-	$this->input->get('vendor_id', '', 'INTEGER') . '&client=' . $this->input->get('client', '', 'STRING')
-	); ?>"
-		method="post" enctype="multipart/form-data" name="adminForm" id="adminForm" class="form-validate">
+	<form action="<?php echo Route::_('index.php?option=com_tjvendors&layout=edit&vendor_id=' . $this->input->get('vendor_id', '', 'INTEGER') . '&client=' . $this->input->get('client', '', 'STRING')); ?>" method="post" enctype="multipart/form-data" name="adminForm" id="adminForm" class="form-validate">
 		<div class="row">
 			<div class="col-sm-12 vendorForm" id="tj-edit-form">
 			<?php

--- a/src/com_tjvendors/site/views/vendor/tmpl/edit.php
+++ b/src/com_tjvendors/site/views/vendor/tmpl/edit.php
@@ -58,16 +58,10 @@ if (Factory::getUser()->id)
 	<form action="<?php echo Route::_('index.php?option=com_tjvendors&layout=edit&vendor_id=' . $this->input->get('vendor_id', '', 'INTEGER') . '&client=' . $this->input->get('client', '', 'STRING')); ?>" method="post" enctype="multipart/form-data" name="adminForm" id="adminForm" class="form-validate">
 		<div class="row">
 			<div class="col-sm-12 vendorForm" id="tj-edit-form">
-			<?php
-				if (!$this->isClientExist)
-				{
-					?>
-					<ul class="nav nav-tabs vendorForm__nav d-flex mb-15">
-						<li class="active"><a data-toggle="tab" href="#tab1"><?php echo Text::_('COM_TJVENDORS_TITLE_PERSONAL'); ?></a> </li>
-						<li><a data-toggle="tab" href="#tab2"><?php echo Text::_('COM_TJVENDORS_VENDOR_PAYMENT_GATEWAY_DETAILS'); ?></a></li>
-					</ul>
-			<?php
-				} ?>
+				<ul class="nav nav-tabs vendorForm__nav d-flex mb-15">
+					<li class="active"><a data-toggle="tab" href="#tab1"><?php echo Text::_('COM_TJVENDORS_TITLE_PERSONAL'); ?></a> </li>
+					<li><a data-toggle="tab" href="#tab2"><?php echo Text::_('COM_TJVENDORS_VENDOR_PAYMENT_GATEWAY_DETAILS'); ?></a></li>
+				</ul>
 				<!----Tab Container Start----->
 				<div class="tab-content">
 					<!----Tab 1 Start----->


### PR DESCRIPTION
For editing the vendor from the frontend was not showing the Payment Gateways Details tab. 
And hence if the vendor had not been added Payment gateway details while becoming vendor first time, they can't add it later from the frontend. Because of that vendor profile is not completing 100 %