### PR TITLE
Bug #161396 fix: vendor profile page -> Display Warning message 'Register as a vendor'.

### DIFF
--- a/src/com_tjvendors/site/views/vendor/view.html.php
+++ b/src/com_tjvendors/site/views/vendor/view.html.php
@@ -150,7 +150,7 @@ class TjvendorsViewVendor extends HtmlView
 				$app    = Factory::getApplication();
 				$client = $app->input->get('client', '', 'STRING');
 				$link   = Route::_('index.php?option=com_tjvendors&view=vendor&layout=edit&client=' . $client);
-				$app->enqueueMessage(Text::_('COM_TJVENDOR_REGISTRATION_VENDOR_ERROR'), 'warning');
+				$app->enqueueMessage(Text::_('COM_TJVENDOR_REGISTRATION_VENDOR_ERROR'), 'notice');
 				$app->redirect($link);
 			}
 			elseif(!Factory::getUser()->id)


### PR DESCRIPTION
As Joomla user logged in to the site first time and seeing Vendor Profile view, system redirects it on Vendor creation form to become vendor but showing the warning.