### PR TITLE
Bug #167827 fix: Showing incomplete vendor profile

### DIFF
--- a/src/com_tjvendors/site/includes/vendor.php
+++ b/src/com_tjvendors/site/includes/vendor.php
@@ -636,14 +636,15 @@ class TjvendorsVendor extends CMSObject
 	/**
 	 * This function return vendor profile complete/incomplete status
 	 *
-	 * @param   Integer  $userId  userId
-	 * @param   Integer  $client  client
+	 * @param   Integer  $userId               userId
+	 * @param   Integer  $client               client
+	 * @param   String   $sendPaymentsToOwner  send payment directly to owner configuration field value
 	 *
 	 * @return  Interger  Percentage of vendor profile completion
 	 *
 	 * @since   1.4.0
 	 */
-	public function getVendorProfileStatus($userId, $client)
+	public function getVendorProfileStatus($userId, $client, $sendPaymentsToOwner = '0')
 	{
 		$data = $this->loadByUserId($userId, $client);
 
@@ -660,7 +661,15 @@ class TjvendorsVendor extends CMSObject
 		$total += (!empty($data->vat_number)) ? 5: 0;
 		$total += (!empty($data->vendor_description)) ? 5: 0;
 		$total += (!empty($data->vendor_logo))? 5: 0;
-		$total += (!empty($data->payment_gateway)) ? 5: 0;
+
+		if ($sendPaymentsToOwner == '0')
+		{
+			$total += (!empty($data->payment_gateway)) ? 5: 0;
+		}
+		elseif ($sendPaymentsToOwner == '1')
+		{
+			$total += 5;
+		}
 
 		return $total;
 	}


### PR DESCRIPTION
If "Send payments directly to campaign promoter without charging any commissions (works only with Paypal payment gateway)" as Yes in that case profile should display 100% if vendor has filled remaining all details.

If "Send payments directly to campaign promoter without charging any commissions (works only with Paypal payment gateway)" as No, in that case payment gateway details should be considered to complete vendor profile.