### PR TITLE
Bug #188795 Fixed: While creating fees for vendor from backend in "Cu…

### DIFF
--- a/src/com_tjvendors/admin/models/forms/vendorfee.xml
+++ b/src/com_tjvendors/admin/models/forms/vendorfee.xml
@@ -29,7 +29,7 @@
 
 		<field
 			name="currency"
-			type="text"
+			type="currencylist"
 			label="COM_TJVENDORS_FORM_LBL_VENDOR_CURRENCY"
 			description="COM_TJVENDORS_FORM_DESC_VENDOR_CURRENCY"
 			required="true"


### PR DESCRIPTION
…rrency" it is expected that field is accepting word describing currency for ex USD,Rs...but it is accepting numbers for ex.100 etc.PFA for reference.