### PR TITLE
Issue #239667 Fix : Multiple vendors are able to be created with single username

### DIFF
--- a/src/com_tjvendors/admin_language/en-GB/en-GB.com_tjvendors.ini
+++ b/src/com_tjvendors/admin_language/en-GB/en-GB.com_tjvendors.ini
@@ -277,4 +277,5 @@ COM_TJVENDORS_FIX_DATABASE="Fix Database"
 
 ; Since v1.4.3
 COM_TJVENDORS_PAYOUTS_SAVE_SUCCESS="Payout Successsfully Done."
+COM_TJVENDORS_ERROR_USER_ALREADY_VENDOR="You are already associated with a vendor. A user can only be linked to one vendor."
 

--- a/src/com_tjvendors/site/models/vendor.php
+++ b/src/com_tjvendors/site/models/vendor.php
@@ -375,6 +375,25 @@ class TjvendorsModelVendor extends AdminModel
 	 */
 	public function save($data)
 	{
+		$db = Factory::getDbo();
+		$user = Factory::getUser();
+		$app = Factory::getApplication();
+
+		// Check if the user is already associated with a vendor
+		$query = $db->getQuery(true)
+			->select($db->quoteName('vendor_id'))
+			->from($db->quoteName('#__tjvendors_vendors'))
+			->where($db->quoteName('user_id') . ' = ' . (int) $data['user_id']);
+		$db->setQuery($query);
+		$existingVendorId = $db->loadResult();
+
+		if (!empty($existingVendorId) && (empty($data['vendor_id']) || $data['vendor_id'] != $existingVendorId))
+		{
+			// If the user is already associated with a vendor, throw an error
+			$app->enqueueMessage(Text::_('COM_TJVENDORS_ERROR_USER_ALREADY_VENDOR'), 'error');
+			return false;
+		}
+
 		$table    = $this->getTable();
 		$db       = Factory::getDbo();
 		$user     = Factory::getUser();


### PR DESCRIPTION
…le username.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an error message to notify users if they attempt to associate a user with more than one vendor.
  - The system now prevents users from being linked to multiple vendors and displays a clear error message when this occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->